### PR TITLE
[WLIOS-41757] Add reset permission endpoint

### DIFF
--- a/Sources/MusselServer/ServerManager.swift
+++ b/Sources/MusselServer/ServerManager.swift
@@ -11,6 +11,7 @@ class ServerManager {
     private let uninstallAppEndpoint = "/simulatorUninstallApp"
     private let overrideStatusBarEndpoint = "/overrideStatusBar"
     private let addmediaEndpoint = "/addmedia"
+    private let resetPermissionEndpoint = "/resetPermission"
 
     public func startServer() {
         do {
@@ -20,6 +21,7 @@ class ServerManager {
             setupUninstallAppEndpoint()
             setupOverrideStatusBarEndpoint()
             setupMediaUploadEndpoint()
+            setupResetPermissionEndpoint()
         } catch {
             _ = SocketError.bindFailed(Errno.description()).localizedDescription
             print("Error starting Mussel server")
@@ -79,6 +81,27 @@ class ServerManager {
         }
 
         server.POST[universalLinkEndpoint] = response
+    }
+    
+    private func setupResetPermissionEndpoint() {
+        let response: ((HttpRequest) -> HttpResponse) = { [weak self] request in
+            guard let serializedObject = try? JSONSerialization.jsonObject(with: Data(request.body), options: []),
+                  let json = serializedObject as? JSON,
+                  let simulatorId = json["simulatorId"] as? String,
+                  let appBundleId = json["appBundleId"] as? String,
+                  let permission = json["permission"] as? String
+            else {
+                return HttpResponse.badRequest(nil)
+            }
+
+            let command = "xcrun simctl privacy \(simulatorId) reset \(permission) \(appBundleId)"
+            let result = self?.run(command: command)
+            let responseInfo = "Ran command: \(command) \n Result:\n \(result ?? "Empty result")"
+            print(responseInfo)
+            return .ok(.text(responseInfo))
+        }
+
+        server.POST[resetPermissionEndpoint] = response
     }
     
     private func setupMediaUploadEndpoint() {


### PR DESCRIPTION
Потрібно виконати команду `xcrun simctl privacy \(simulatorId) reset motion \(appBundleId)` для того, щоб скинути пермішени з доступом до motion